### PR TITLE
Fix page number indexing in poliqarp output

### DIFF
--- a/revealshapes.cpp
+++ b/revealshapes.cpp
@@ -112,7 +112,7 @@ int process_document(int page_from, int page_to, GP<DjVuDocument> doc) {
 							//<file-name> d-<blit number>-<blit shapeno>;file:<file-name>?djvuopts=&highlight=<left>,<blit bottom>,<shape bit columns>,<rows>&page=<page number + 1>; <file-name> d-<blit number>-<blit shapeno>;
 							std::cout << s.replace_extension().filename();
 							std::cout <<" d-" <<i <<"-" << blit->shapeno << ";";
-							std::cout << "file:" << sorigString << "?djvuopts=&highlight=" << blit->left << "," << blit->bottom << "," << shape.bits->columns() << "," << shape.bits->rows()<< "&page="<<page_number<<";";
+std::cout << "file:" << sorigString << "?djvuopts=&highlight=" << blit->left << "," << blit->bottom << "," << shape.bits->columns() << "," << shape.bits->rows() << "&page=" << (page_number + 1) << ";";
 							std::cout << s.filename() <<" d-" <<i <<"-" << blit->shapeno << std::endl;
 						} else {
 							std::cout << ((blit->shapeno < inh_sh_count)?"s":"d") << "," << page_number << "," << i << "," << blit->shapeno  << "," << shape.bits->columns() << ","  << shape.bits->rows() << ","  << shape.bits->rowsize() << "," << blit->bottom << ","  << blit->left << endl;


### PR DESCRIPTION
This PR corrects the page numbering offset in the poliqarp-style output by making page indices 1-based (instead of 0-based). This change ensures compatibility with DjVu viewers that expect pages to start from 1.